### PR TITLE
Removes unused option (was deprecated before 1.0.0)

### DIFF
--- a/src/create-bin-tester.ts
+++ b/src/create-bin-tester.ts
@@ -67,7 +67,6 @@ type RunBinArgs = [...binArgs: string[], execaOptions: execa.Options<string>];
 
 const DEFAULT_BIN_TESTER_OPTIONS = {
   staticArgs: [],
-  projectConstructor: BinTesterProject,
 };
 
 /**


### PR DESCRIPTION
The `projectConstructor` option was removed in favor of defining creation in `createProject`. This was a remnant of the old options, so removing it. It's not breaking since it was not used prior to 1.0.0