### PR TITLE
Adds support for supplying a binPath dynamically

### DIFF
--- a/src/create-bin-tester.ts
+++ b/src/create-bin-tester.ts
@@ -4,7 +4,7 @@ interface BinTesterOptions<TProject> {
   /**
    * The absolute path to the bin to invoke
    */
-  binPath: string;
+  binPath: string | (<TProject extends BinTesterProject>(project: TProject) => string);
   /**
    * An array of static arguments that will be used every time when running the bin
    */
@@ -113,10 +113,14 @@ export function createBinTester<TProject extends BinTesterProject>(
    */
   function runBin(...args: RunBinArgs): execa.ExecaChildProcess<string> {
     const mergedRunOptions = parseArgs(args);
+    const binPath =
+      typeof mergedOptions.binPath === 'function'
+        ? mergedOptions.binPath(project)
+        : mergedOptions.binPath;
 
     return execa(
       process.execPath,
-      [mergedOptions.binPath, ...mergedOptions.staticArgs, ...mergedRunOptions.args],
+      [binPath, ...mergedOptions.staticArgs, ...mergedRunOptions.args],
       {
         reject: false,
         cwd: project.baseDir,

--- a/tests/index-test.ts
+++ b/tests/index-test.ts
@@ -78,6 +78,25 @@ describe('createBinTester', () => {
     expect(existsSync(project.baseDir)).toEqual(false);
   });
 
+  test('runBin can run the configured bin script dynamically', async () => {
+    const { setupProject, teardownProject, runBin } = createBinTester({
+      binPath: (p) => {
+        expect(p).toEqual(project);
+        return fileURLToPath(new URL('fixtures/fake-bin.js', import.meta.url));
+      },
+    });
+
+    const project = await setupProject();
+
+    const result = await runBin();
+
+    expect(result.stdout).toMatchInlineSnapshot('"I am a bin who takes args []"');
+
+    teardownProject();
+
+    expect(existsSync(project.baseDir)).toEqual(false);
+  });
+
   test('runBin can run the configured bin script with static arguments', async () => {
     const { setupProject, teardownProject, runBin } = createBinTester({
       binPath: fileURLToPath(new URL('fixtures/fake-bin.js', import.meta.url)),


### PR DESCRIPTION
In some cases, we need to be able to supply the `binPath` dynamically, such as if the bin is part of a dependency _within_ the `Project` itself. This is only possible dynamically, since the project is dynamically created and destroyed. 

This change widens the type of `binPath`:

```ts
binPath: string | (<TProject extends BinTesterProject>(project: TProject) => string);
```