### PR TITLE
Fixes runBin TS signature to accommodate optional execa.Options

### DIFF
--- a/src/create-bin-tester.ts
+++ b/src/create-bin-tester.ts
@@ -35,14 +35,34 @@ interface RunBin {
    */
   (): execa.ExecaChildProcess<string>;
   /**
-   * A runBin implementation that takes varargs.
+   * A runBin implementation that takes string varargs.
    *
    * @param {...RunBinArgs} args
    * @returns {*}  {execa.ExecaChildProcess<string>}
    * @memberof RunBin
    */
-  (...args: RunBinArgs): execa.ExecaChildProcess<string>;
+  (...args: [...binArgs: string[]]): execa.ExecaChildProcess<string>;
+  /**
+   * A runBin implementation that takes an execa.Options<string> object.
+   *
+   * @param {...RunBinArgs} args
+   * @returns {*}  {execa.ExecaChildProcess<string>}
+   * @memberof RunBin
+   */
+  (...args: [execaOptions: execa.Options<string>]): execa.ExecaChildProcess<string>;
+  /**
+   * A runBin implementation that takes string or an execa.Options<string> object varargs.
+   *
+   * @param {...RunBinArgs} args
+   * @returns {*}  {execa.ExecaChildProcess<string>}
+   * @memberof RunBin
+   */
+  (
+    ...args: [...binArgs: string[], execaOptions: execa.Options<string>]
+  ): execa.ExecaChildProcess<string>;
 }
+
+type RunBinArgs = (string | execa.Options<string>)[];
 
 interface CreateBinTesterResult<TProject extends BinTesterProject> {
   /**
@@ -62,8 +82,6 @@ interface CreateBinTesterResult<TProject extends BinTesterProject> {
    */
   teardownProject: () => void;
 }
-
-type RunBinArgs = [...binArgs: string[], execaOptions: execa.Options<string>];
 
 const DEFAULT_BIN_TESTER_OPTIONS = {
   staticArgs: [],


### PR DESCRIPTION
The current `RunBin` signatures only handled 2 cases: when there were no arguments passed, or when there was string varags _and_ an `execa.Options<string>`. These signatures didn't accommodate the case where you could have only string varargs or only an `execa.Options<string>` object.

This PR adds the extra overloads.