### PR TITLE
fix: Fixes CI and removes lower node versions

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -17,7 +17,7 @@ jobs:
 
     strategy:
       matrix:
-        node: ['12', '14', '16', '18', '20', '22']
+        node: ['18', '20', '22']
 
     steps:
       - uses: actions/checkout@v4

--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
     "vitest": "^3.1.1"
   },
   "engines": {
-    "node": ">=14"
+    "node": ">=18"
   },
   "publishConfig": {
     "registry": "https://registry.npmjs.org",


### PR DESCRIPTION
This pull request includes updates to the Node.js versions used in the CI build workflow and the `package.json` file to ensure compatibility with the latest Node.js versions.

Updates to Node.js versions:

* [`.github/workflows/ci-build.yml`](diffhunk://#diff-68ba9d12f6f2601fe3c9f7f9d0d02aaea52384559d6d08fae7afc941663fdfcdL20-R20): Removed older Node.js versions (12, 14, 16) from the matrix strategy, now only supporting Node.js versions 18, 20, and 22.
* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L72-R72): Updated the minimum required Node.js version from 14 to 18.