### PR TITLE
Fix spelling in teardown docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -172,7 +172,7 @@ describe('Some tests', () => {
 <a name="createBinTester..teardownProject"></a>
 
 ### createBinTester~teardownProject()
-<p>Tears the project down, ensuring the tmp directory is removed. Shoud be paired with setupProject.</p>
+<p>Tears the project down, ensuring the tmp directory is removed. Should be paired with setupProject.</p>
 
 **Kind**: inner method of [<code>createBinTester</code>](#createBinTester)  
 

--- a/src/create-bin-tester.ts
+++ b/src/create-bin-tester.ts
@@ -74,7 +74,7 @@ interface CreateBinTesterResult<TProject extends BinTesterProject> {
    */
   setupTmpDir: () => Promise<string>;
   /**
-   * Tears the project down, ensuring the tmp directory is removed. Shoud be paired with setupProject.
+   * Tears the project down, ensuring the tmp directory is removed. Should be paired with setupProject.
    */
   teardownProject: () => void;
 }
@@ -167,7 +167,7 @@ export function createBinTester<TProject extends BinTesterProject>(
   }
 
   /**
-   * Tears the project down, ensuring the tmp directory is removed. Shoud be paired with setupProject.
+   * Tears the project down, ensuring the tmp directory is removed. Should be paired with setupProject.
    */
   function teardownProject() {
     project.dispose();


### PR DESCRIPTION
## Summary
- correct the spelling for `Should` in teardown comments
- keep the README consistent