### PR TITLE
docs: Add CLAUDE.md for Claude Code guidance

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,48 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+bin-tester is a test harness for Node.js CLI tools. It creates temporary directories with fixture files, spawns CLI binaries as subprocesses, and captures their output for assertion.
+
+## Commands
+
+```bash
+npm test              # Run lint + tests
+npm run test:vitest   # Run tests only
+npm run lint          # ESLint + Prettier check + markdown-code check
+npm run build         # Build CJS and ESM with tsup
+npm run docs          # Generate TypeDoc API documentation
+npm run format        # Format all files with Prettier
+```
+
+Run a single test:
+```bash
+npx vitest run -t "test name pattern"
+```
+
+## Architecture
+
+The library exports two main pieces:
+
+1. **`createBinTester(options)`** - Factory function that returns test helpers:
+   - `setupProject()` - Creates a temp directory with a `BinTesterProject`
+   - `teardownProject()` - Cleans up the temp directory
+   - `runBin(...args)` - Executes the configured CLI binary via `execaNode`
+   - `runBinDebug(...args)` - Same as `runBin` but with Node inspector enabled
+
+2. **`BinTesterProject`** - Extends `fixturify-project`'s `Project` class. Provides:
+   - `files` property for defining fixture files
+   - `write()` to persist files to the temp directory
+   - `gitInit()` to initialize a git repo
+   - `chdir()` / `dispose()` for directory management
+
+## Key Dependencies
+
+- **execa v9** - Subprocess execution. Uses `execaNode` for running Node scripts with `nodeOptions` for inspector flags.
+- **fixturify-project** - Temp directory and fixture file management.
+
+## Debugging Tests
+
+Set `BIN_TESTER_DEBUG=attach` or `BIN_TESTER_DEBUG=break` to enable Node inspector and preserve fixture directories after test runs.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,6 +18,7 @@ npm run format        # Format all files with Prettier
 ```
 
 Run a single test:
+
 ```bash
 npx vitest run -t "test name pattern"
 ```


### PR DESCRIPTION
## Summary

- Adds CLAUDE.md to provide Claude Code with project-specific context

### Contents

- Common commands (build, test, lint, docs, run single test)
- Architecture overview of the two main exports (`createBinTester` and `BinTesterProject`)
- Key dependencies (execa v9, fixturify-project)
- Debugging with `BIN_TESTER_DEBUG` environment variable

## Test plan

- [x] File follows CLAUDE.md format requirements
- [x] Contains accurate project information

🤖 Generated with [Claude Code](https://claude.com/claude-code)