### PR TITLE
Rename package from @scalvert/bin-tester to testdrive

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project Overview
 
-bin-tester is a test harness for Node.js CLI tools. It creates temporary directories with fixture files, spawns CLI binaries as subprocesses, and captures their output for assertion.
+testdrive is a test harness for Node.js CLI tools. It creates temporary directories with fixture files, spawns CLI binaries as subprocesses, and captures their output for assertion.
 
 ## Commands
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -27,13 +27,13 @@ npx vitest run -t "test name pattern"
 
 The library exports two main pieces:
 
-1. **`createBinTester(options)`** - Factory function that returns test helpers:
-   - `setupProject()` - Creates a temp directory with a `BinTesterProject`
+1. **`createTestDriver(options)`** - Factory function that returns test helpers:
+   - `setupProject()` - Creates a temp directory with a `TestDriveProject`
    - `teardownProject()` - Cleans up the temp directory
    - `runBin(...args)` - Executes the configured CLI binary via `execaNode`
    - `runBinDebug(...args)` - Same as `runBin` but with Node inspector enabled
 
-2. **`BinTesterProject`** - Extends `fixturify-project`'s `Project` class. Provides:
+2. **`TestDriveProject`** - Extends `fixturify-project`'s `Project` class. Provides:
    - `files` property for defining fixture files
    - `write()` to persist files to the temp directory
    - `gitInit()` to initialize a git repo
@@ -46,4 +46,4 @@ The library exports two main pieces:
 
 ## Debugging Tests
 
-Set `BIN_TESTER_DEBUG=attach` or `BIN_TESTER_DEBUG=break` to enable Node inspector and preserve fixture directories after test runs.
+Set `TESTDRIVE_DEBUG=attach` or `TESTDRIVE_DEBUG=break` to enable Node inspector and preserve fixture directories after test runs.

--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@
 ![Dependabot](https://badgen.net/badge/icon/dependabot?icon=dependabot&label)
 [![Code Style: prettier](https://img.shields.io/badge/code_style-prettier-ff69b4.svg?style=flat-square)](#badge)
 
+> **Note:** This package was formerly published as `@scalvert/bin-tester`.
+
 A test harness for Node.js CLI tools.
 
 Testing a CLI isn't like testing a library—you can't just import functions and call them. You need to spawn your CLI as a subprocess, give it real files to work with, and capture its output. testdrive simplifies this:

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ A test harness for Node.js CLI tools.
 Testing a CLI isn't like testing a library—you can't just import functions and call them. You need to spawn your CLI as a subprocess, give it real files to work with, and capture its output. testdrive simplifies this:
 
 ```ts snippet=basic-example.ts
-import { createBinTester } from 'testdrive';
+import { createBinTester } from '@scalvert/bin-tester';
 
 describe('my-cli', () => {
   const { setupProject, teardownProject, runBin } = createBinTester({

--- a/README.md
+++ b/README.md
@@ -1,17 +1,17 @@
-# @scalvert/bin-tester
+# testdrive
 
-![CI Build](https://github.com/scalvert/bin-tester/workflows/CI%20Build/badge.svg)
-[![npm version](https://badge.fury.io/js/%40scalvert%2Fbin-tester.svg)](https://badge.fury.io/js/%40scalvert%2Fbin-tester)
-[![License](https://img.shields.io/npm/l/@scalvert/bin-tester.svg)](https://github.com/scalvert/bin-tester/blob/master/package.json)
+![CI Build](https://github.com/scalvert/testdrive/workflows/CI%20Build/badge.svg)
+[![npm version](https://badge.fury.io/js/testdrive.svg)](https://badge.fury.io/js/testdrive)
+[![License](https://img.shields.io/npm/l/testdrive.svg)](https://github.com/scalvert/testdrive/blob/master/package.json)
 ![Dependabot](https://badgen.net/badge/icon/dependabot?icon=dependabot&label)
 [![Code Style: prettier](https://img.shields.io/badge/code_style-prettier-ff69b4.svg?style=flat-square)](#badge)
 
 A test harness for Node.js CLI tools.
 
-Testing a CLI isn't like testing a library—you can't just import functions and call them. You need to spawn your CLI as a subprocess, give it real files to work with, and capture its output. bin-tester simplifies this:
+Testing a CLI isn't like testing a library—you can't just import functions and call them. You need to spawn your CLI as a subprocess, give it real files to work with, and capture its output. testdrive simplifies this:
 
 ```ts snippet=basic-example.ts
-import { createBinTester } from '@scalvert/bin-tester';
+import { createBinTester } from 'testdrive';
 
 describe('my-cli', () => {
   const { setupProject, teardownProject, runBin } = createBinTester({
@@ -43,7 +43,7 @@ describe('my-cli', () => {
 ## Install
 
 ```bash
-npm add @scalvert/bin-tester --save-dev
+npm add testdrive --save-dev
 ```
 
 ## Usage
@@ -116,4 +116,4 @@ For VS Code, add to `.vscode/launch.json`:
 
 ## API
 
-See the [full API documentation](https://scalvert.github.io/bin-tester/).
+See the [full API documentation](https://scalvert.github.io/testdrive/).

--- a/README.md
+++ b/README.md
@@ -11,10 +11,10 @@ A test harness for Node.js CLI tools.
 Testing a CLI isn't like testing a library—you can't just import functions and call them. You need to spawn your CLI as a subprocess, give it real files to work with, and capture its output. testdrive simplifies this:
 
 ```ts snippet=basic-example.ts
-import { createBinTester } from '@scalvert/bin-tester';
+import { createTestDriver } from 'testdrive';
 
 describe('my-cli', () => {
-  const { setupProject, teardownProject, runBin } = createBinTester({
+  const { setupProject, teardownProject, runBin } = createTestDriver({
     binPath: './bin/my-cli.js',
   });
 
@@ -48,10 +48,10 @@ npm add testdrive --save-dev
 
 ## Usage
 
-`createBinTester` returns helpers for setting up projects, running your CLI, and cleaning up:
+`createTestDriver` returns helpers for setting up projects, running your CLI, and cleaning up:
 
-```ts snippet=create-bin-tester.ts
-const { setupProject, teardownProject, runBin } = createBinTester({
+```ts snippet=create-test-driver.ts
+const { setupProject, teardownProject, runBin } = createTestDriver({
   binPath: './bin/my-cli.js',
   staticArgs: ['--verbose'], // args passed to every invocation
 });
@@ -87,11 +87,11 @@ result.stderr; // string
 
 ## Debugging
 
-Set `BIN_TESTER_DEBUG` to enable the Node inspector and preserve fixtures for inspection:
+Set `TESTDRIVE_DEBUG` to enable the Node inspector and preserve fixtures for inspection:
 
 ```bash
-BIN_TESTER_DEBUG=attach npm test  # attach debugger
-BIN_TESTER_DEBUG=break npm test   # break on first line
+TESTDRIVE_DEBUG=attach npm test  # attach debugger
+TESTDRIVE_DEBUG=break npm test   # break on first line
 ```
 
 Or use `runBinDebug()` programmatically:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "@scalvert/bin-tester",
+  "name": "testdrive",
   "version": "3.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "@scalvert/bin-tester",
+      "name": "testdrive",
       "version": "3.0.0",
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,17 +1,21 @@
 {
-  "name": "@scalvert/bin-tester",
+  "name": "testdrive",
   "version": "3.0.0",
-  "description": "A test harness to invoke a CLI in a tmp directory",
+  "description": "A test harness for Node.js CLI tools",
   "keywords": [
     "cli",
-    "fake",
-    "project",
     "test",
-    "harness"
+    "harness",
+    "binary",
+    "subprocess"
   ],
   "repository": {
     "type": "git",
-    "url": "https://github.com/scalvert/bin-tester.git"
+    "url": "https://github.com/scalvert/testdrive.git"
+  },
+  "homepage": "https://github.com/scalvert/testdrive#readme",
+  "bugs": {
+    "url": "https://github.com/scalvert/testdrive/issues"
   },
   "license": "MIT",
   "author": "Steve Calvert <steve.calvert@gmail.com>",

--- a/snippets/basic-example.ts
+++ b/snippets/basic-example.ts
@@ -1,7 +1,7 @@
-import { createBinTester } from '@scalvert/bin-tester';
+import { createTestDriver } from 'testdrive';
 
 describe('my-cli', () => {
-  const { setupProject, teardownProject, runBin } = createBinTester({
+  const { setupProject, teardownProject, runBin } = createTestDriver({
     binPath: './bin/my-cli.js',
   });
 

--- a/snippets/create-test-driver.ts
+++ b/snippets/create-test-driver.ts
@@ -1,4 +1,4 @@
-const { setupProject, teardownProject, runBin } = createBinTester({
+const { setupProject, teardownProject, runBin } = createTestDriver({
   binPath: './bin/my-cli.js',
   staticArgs: ['--verbose'], // args passed to every invocation
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,7 @@
 export {
-  createBinTester,
-  BinTesterOptions,
-  CreateBinTesterResult,
+  createTestDriver,
+  TestDriveOptions,
+  CreateTestDriverResult,
   RunBin,
-} from './create-bin-tester';
-export { default as BinTesterProject } from './project';
+} from './create-test-driver';
+export { default as TestDriveProject } from './project';

--- a/src/project.ts
+++ b/src/project.ts
@@ -3,11 +3,11 @@ import { Project } from 'fixturify-project';
 
 const ROOT = process.cwd();
 
-export default class BinTesterProject extends Project {
+export default class TestDriveProject extends Project {
   private _dirChanged = false;
 
   /**
-   * Constructs an instance of a BinTesterProject.
+   * Constructs an instance of a TestDriveProject.
    * @param {string} name - The name of the project. Used within the package.json as the name property.
    * @param {string} version - The version of the project. Used within the package.json as the version property.
    * @param {Function} cb - An optional callback for additional setup steps after the project is constructed.

--- a/tests/fixtures/fake-bin-with-env.js
+++ b/tests/fixtures/fake-bin-with-env.js
@@ -1,3 +1,3 @@
 #!/usr/bin/node
 
-console.log('I am an env var', process.env.BIN_TESTER);
+console.log('I am an env var', process.env.TESTDRIVE);

--- a/typedoc.json
+++ b/typedoc.json
@@ -2,7 +2,7 @@
   "$schema": "https://typedoc.org/schema.json",
   "entryPoints": ["./src/index.ts"],
   "out": "./docs",
-  "name": "@scalvert/bin-tester",
+  "name": "testdrive",
   "readme": "none",
   "excludePrivate": true,
   "excludeInternal": true,


### PR DESCRIPTION
## Summary
- Rebrand package from `@scalvert/bin-tester` to `testdrive`
- Update package.json metadata (name, description, keywords, URLs)
- Rename all public APIs:
  - `createBinTester` → `createTestDriver`
  - `BinTesterProject` → `TestDriveProject`
  - `BinTesterOptions` → `TestDriveOptions`
  - `CreateBinTesterResult` → `CreateTestDriverResult`
  - `BIN_TESTER_DEBUG` → `TESTDRIVE_DEBUG`
- Rename source files (`create-bin-tester.ts` → `create-test-driver.ts`)
- Update README badges, install command, and import examples
- Update CLAUDE.md project description and API references
- Update all tests and snippets

## Test plan
- [x] All 13 tests pass
- [x] Lint passes
- [x] Build succeeds with new names
- [ ] Verify npm publish works with new name
- [ ] Deprecate old `@scalvert/bin-tester` package

🤖 Generated with [Claude Code](https://claude.com/claude-code)