### PR TITLE
Rename package from testdrive to bintastic

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -4,7 +4,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 
 ## Project Overview
 
-testdrive is a test harness for Node.js CLI tools. It creates temporary directories with fixture files, spawns CLI binaries as subprocesses, and captures their output for assertion.
+bintastic is a test harness for Node.js CLI tools. It creates temporary directories with fixture files, spawns CLI binaries as subprocesses, and captures their output for assertion.
 
 ## Commands
 
@@ -27,13 +27,13 @@ npx vitest run -t "test name pattern"
 
 The library exports two main pieces:
 
-1. **`createTestDriver(options)`** - Factory function that returns test helpers:
-   - `setupProject()` - Creates a temp directory with a `TestDriveProject`
+1. **`createBintastic(options)`** - Factory function that returns test helpers:
+   - `setupProject()` - Creates a temp directory with a `BintasticProject`
    - `teardownProject()` - Cleans up the temp directory
    - `runBin(...args)` - Executes the configured CLI binary via `execaNode`
    - `runBinDebug(...args)` - Same as `runBin` but with Node inspector enabled
 
-2. **`TestDriveProject`** - Extends `fixturify-project`'s `Project` class. Provides:
+2. **`BintasticProject`** - Extends `fixturify-project`'s `Project` class. Provides:
    - `files` property for defining fixture files
    - `write()` to persist files to the temp directory
    - `gitInit()` to initialize a git repo
@@ -46,4 +46,4 @@ The library exports two main pieces:
 
 ## Debugging Tests
 
-Set `TESTDRIVE_DEBUG=attach` or `TESTDRIVE_DEBUG=break` to enable Node inspector and preserve fixture directories after test runs.
+Set `BINTASTIC_DEBUG=attach` or `BINTASTIC_DEBUG=break` to enable Node inspector and preserve fixture directories after test runs.

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
-# testdrive
+# bintastic
 
-![CI Build](https://github.com/scalvert/testdrive/workflows/CI%20Build/badge.svg)
-[![npm version](https://badge.fury.io/js/testdrive.svg)](https://badge.fury.io/js/testdrive)
-[![License](https://img.shields.io/npm/l/testdrive.svg)](https://github.com/scalvert/testdrive/blob/master/package.json)
+![CI Build](https://github.com/scalvert/bintastic/workflows/CI%20Build/badge.svg)
+[![npm version](https://badge.fury.io/js/bintastic.svg)](https://badge.fury.io/js/bintastic)
+[![License](https://img.shields.io/npm/l/bintastic.svg)](https://github.com/scalvert/bintastic/blob/master/package.json)
 ![Dependabot](https://badgen.net/badge/icon/dependabot?icon=dependabot&label)
 [![Code Style: prettier](https://img.shields.io/badge/code_style-prettier-ff69b4.svg?style=flat-square)](#badge)
 
@@ -10,13 +10,13 @@
 
 A test harness for Node.js CLI tools.
 
-Testing a CLI isn't like testing a library—you can't just import functions and call them. You need to spawn your CLI as a subprocess, give it real files to work with, and capture its output. testdrive simplifies this:
+Testing a CLI isn't like testing a library—you can't just import functions and call them. You need to spawn your CLI as a subprocess, give it real files to work with, and capture its output. bintastic simplifies this:
 
 ```ts snippet=basic-example.ts
-import { createTestDriver } from 'testdrive';
+import { createBintastic } from 'bintastic';
 
 describe('my-cli', () => {
-  const { setupProject, teardownProject, runBin } = createTestDriver({
+  const { setupProject, teardownProject, runBin } = createBintastic({
     binPath: './bin/my-cli.js',
   });
 
@@ -45,15 +45,15 @@ describe('my-cli', () => {
 ## Install
 
 ```bash
-npm add testdrive --save-dev
+npm add bintastic --save-dev
 ```
 
 ## Usage
 
-`createTestDriver` returns helpers for setting up projects, running your CLI, and cleaning up:
+`createBintastic` returns helpers for setting up projects, running your CLI, and cleaning up:
 
-```ts snippet=create-test-driver.ts
-const { setupProject, teardownProject, runBin } = createTestDriver({
+```ts snippet=create-bintastic.ts
+const { setupProject, teardownProject, runBin } = createBintastic({
   binPath: './bin/my-cli.js',
   staticArgs: ['--verbose'], // args passed to every invocation
 });
@@ -89,11 +89,11 @@ result.stderr; // string
 
 ## Debugging
 
-Set `TESTDRIVE_DEBUG` to enable the Node inspector and preserve fixtures for inspection:
+Set `BINTASTIC_DEBUG` to enable the Node inspector and preserve fixtures for inspection:
 
 ```bash
-TESTDRIVE_DEBUG=attach npm test  # attach debugger
-TESTDRIVE_DEBUG=break npm test   # break on first line
+BINTASTIC_DEBUG=attach npm test  # attach debugger
+BINTASTIC_DEBUG=break npm test   # break on first line
 ```
 
 Or use `runBinDebug()` programmatically:
@@ -118,4 +118,4 @@ For VS Code, add to `.vscode/launch.json`:
 
 ## API
 
-See the [full API documentation](https://scalvert.github.io/testdrive/).
+See the [full API documentation](https://scalvert.github.io/bintastic/).

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "testdrive",
+  "name": "bintastic",
   "version": "3.0.0",
   "description": "A test harness for Node.js CLI tools",
   "keywords": [
@@ -11,11 +11,11 @@
   ],
   "repository": {
     "type": "git",
-    "url": "https://github.com/scalvert/testdrive.git"
+    "url": "https://github.com/scalvert/bintastic.git"
   },
-  "homepage": "https://github.com/scalvert/testdrive#readme",
+  "homepage": "https://github.com/scalvert/bintastic#readme",
   "bugs": {
-    "url": "https://github.com/scalvert/testdrive/issues"
+    "url": "https://github.com/scalvert/bintastic/issues"
   },
   "license": "MIT",
   "author": "Steve Calvert <steve.calvert@gmail.com>",

--- a/snippets/basic-example.ts
+++ b/snippets/basic-example.ts
@@ -1,7 +1,7 @@
-import { createTestDriver } from 'testdrive';
+import { createBintastic } from 'bintastic';
 
 describe('my-cli', () => {
-  const { setupProject, teardownProject, runBin } = createTestDriver({
+  const { setupProject, teardownProject, runBin } = createBintastic({
     binPath: './bin/my-cli.js',
   });
 

--- a/snippets/create-bintastic.ts
+++ b/snippets/create-bintastic.ts
@@ -1,4 +1,4 @@
-const { setupProject, teardownProject, runBin } = createTestDriver({
+const { setupProject, teardownProject, runBin } = createBintastic({
   binPath: './bin/my-cli.js',
   staticArgs: ['--verbose'], // args passed to every invocation
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,7 +1,7 @@
 export {
-  createTestDriver,
-  TestDriveOptions,
-  CreateTestDriverResult,
+  createBintastic,
+  BintasticOptions,
+  CreateBintasticResult,
   RunBin,
-} from './create-test-driver';
-export { default as TestDriveProject } from './project';
+} from './create-bintastic';
+export { default as BintasticProject } from './project';

--- a/src/project.ts
+++ b/src/project.ts
@@ -3,11 +3,11 @@ import { Project } from 'fixturify-project';
 
 const ROOT = process.cwd();
 
-export default class TestDriveProject extends Project {
+export default class BintasticProject extends Project {
   private _dirChanged = false;
 
   /**
-   * Constructs an instance of a TestDriveProject.
+   * Constructs an instance of a BintasticProject.
    * @param {string} name - The name of the project. Used within the package.json as the name property.
    * @param {string} version - The version of the project. Used within the package.json as the version property.
    * @param {Function} cb - An optional callback for additional setup steps after the project is constructed.

--- a/tests/fixtures/fake-bin-with-env.js
+++ b/tests/fixtures/fake-bin-with-env.js
@@ -1,3 +1,3 @@
 #!/usr/bin/node
 
-console.log('I am an env var', process.env.TESTDRIVE);
+console.log('I am an env var', process.env.BINTASTIC);

--- a/typedoc.json
+++ b/typedoc.json
@@ -2,7 +2,7 @@
   "$schema": "https://typedoc.org/schema.json",
   "entryPoints": ["./src/index.ts"],
   "out": "./docs",
-  "name": "testdrive",
+  "name": "bintastic",
   "readme": "none",
   "excludePrivate": true,
   "excludeInternal": true,


### PR DESCRIPTION
## Summary
- Renames the npm package from `testdrive` to `bintastic`
- Updates all exported types and functions (`createTestDriver` → `createBintastic`, `TestDriveProject` → `BintasticProject`, etc.)
- Updates environment variables (`TESTDRIVE_DEBUG` → `BINTASTIC_DEBUG`)
- Updates all documentation, URLs, and references throughout the codebase

## Test plan
- [ ] Verify `npm test` passes
- [ ] Verify `npm run build` completes successfully
- [ ] Confirm all imports and exports work correctly
- [ ] Test that `BINTASTIC_DEBUG` environment variable works as expected

🤖 Generated with [Claude Code](https://claude.com/claude-code)