### PR TITLE
Fix BintasticProject.write() signature and re-export dependency types

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -5,3 +5,5 @@ export {
   RunBin,
 } from './create-bintastic';
 export { default as BintasticProject } from './project';
+export type { DirJSON } from 'fixturify';
+export type { Options, Result, ResultPromise } from 'execa';

--- a/src/project.ts
+++ b/src/project.ts
@@ -1,4 +1,5 @@
 import { execa, type ResultPromise } from 'execa';
+import type { DirJSON } from 'fixturify';
 import { Project } from 'fixturify-project';
 
 const ROOT = process.cwd();
@@ -32,9 +33,10 @@ export default class BintasticProject extends Project {
 
   /**
    * Writes the project files to disk.
+   * @param {DirJSON} dirJSON - Optional directory JSON to merge before writing.
    */
-  async write(): Promise<void> {
-    return super.write();
+  async write(dirJSON?: DirJSON): Promise<void> {
+    return super.write(dirJSON);
   }
 
   /**


### PR DESCRIPTION
## Summary
- Fixes `write()` method signature to match parent class by accepting optional `DirJSON` parameter
- Re-exports `DirJSON` type from fixturify for fixture definitions
- Re-exports `Options`, `Result`, and `ResultPromise` types from execa for consumers working with `runBin` return values

## Test plan
- [ ] Verify `npm run build` completes successfully
- [ ] Verify `npm test` passes
- [ ] Confirm `project.write({ 'file.txt': 'content' })` no longer causes TypeScript errors
- [ ] Confirm re-exported types are accessible via `import { DirJSON, Options, Result, ResultPromise } from 'bintastic'`

🤖 Generated with [Claude Code](https://claude.com/claude-code)