### PR TITLE
fix: remove TProject generic shadowing in binPath (CHK-001)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 dist/
 docs/
 node_modules
+.worktrees/

--- a/src/create-bintastic.ts
+++ b/src/create-bintastic.ts
@@ -7,7 +7,7 @@ export interface BintasticOptions<TProject> {
   /**
    * The absolute path to the bin to invoke
    */
-  binPath: string | (<TProject extends BintasticProject>(project: TProject) => string);
+  binPath: string | ((project: TProject) => string);
   /**
    * An array of static arguments that will be used every time when running the bin
    */


### PR DESCRIPTION
## Summary
- Removes inner \`<TProject extends BintasticProject>\` generic from \`binPath\` function type
- The inner generic was shadowing the outer interface generic, causing consumers with custom project subclasses to lose type specificity in the \`binPath\` callback
- The callback now correctly references the outer \`TProject\` generic, so a consumer using \`createProject: () => new CustomProject()\` will receive \`CustomProject\` (not just \`BintasticProject\`) in their \`binPath\` function

## Checklist item
Closes CHK-001 from EVAL-CHECKLIST.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)