### PR TITLE
fix: remove no-op write() override from BintasticProject (CHK-008)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 dist/
 docs/
 node_modules
+.worktrees/

--- a/src/project.ts
+++ b/src/project.ts
@@ -1,5 +1,4 @@
 import { execa, type ResultPromise } from 'execa';
-import type { DirJSON } from 'fixturify';
 import { Project } from 'fixturify-project';
 
 const ROOT = process.cwd();
@@ -29,14 +28,6 @@ export default class BintasticProject extends Project {
    */
   gitInit(): ResultPromise {
     return execa('git', ['init', '-q', this.baseDir]);
-  }
-
-  /**
-   * Writes the project files to disk.
-   * @param {DirJSON} dirJSON - Optional directory JSON to merge before writing.
-   */
-  async write(dirJSON?: DirJSON): Promise<void> {
-    return super.write(dirJSON);
   }
 
   /**


### PR DESCRIPTION
## Summary
- Removes the `write()` method override in `BintasticProject` which only called `super.write(dirJSON)` with no additional behavior
- The override existed only for its JSDoc comment, which created an unnecessary maintenance surface (parent signature changes would not be caught by TypeScript since the override matched exactly)
- Parent class `write()` is now inherited directly
- The unused `DirJSON` import from `fixturify` was also removed since it was only referenced in the removed method signature

## Checklist item
Closes CHK-008 from EVAL-CHECKLIST.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)