### PR TITLE
fix: replace unsafe type casts with accurate types (CHK-002, CHK-003)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 dist/
 docs/
 node_modules
+.worktrees/

--- a/src/create-bintastic.ts
+++ b/src/create-bintastic.ts
@@ -100,17 +100,17 @@ const DEFAULT_BINTASTIC_OPTIONS = {
  */
 function parseArgs(args: RunBinArgs): RunOptions {
   if (args.length > 0 && typeof args[args.length - 1] === 'object') {
-    const argsCopy = [...args];
-    const execaOptions = argsCopy.pop();
+    const last = args[args.length - 1] as Options;
+    const rest = args.slice(0, -1).filter((a): a is string => typeof a === 'string');
     return {
-      args: argsCopy,
-      execaOptions,
-    } as RunOptions;
+      args: rest,
+      execaOptions: last,
+    };
   } else {
     return {
-      args: [...args],
+      args: args.filter((a): a is string => typeof a === 'string'),
       execaOptions: {},
-    } as RunOptions;
+    };
   }
 }
 
@@ -127,7 +127,7 @@ export function createBintastic<TProject extends BintasticProject>(
   const mergedOptions = {
     ...DEFAULT_BINTASTIC_OPTIONS,
     ...options,
-  } as Required<BintasticOptions<TProject>>;
+  } as BintasticOptions<TProject> & { staticArgs: string[] };
 
   /**
    * @param {...RunBinArgs} args - Arguments or execa options.

--- a/src/create-bintastic.ts
+++ b/src/create-bintastic.ts
@@ -188,7 +188,7 @@ export function createBintastic<TProject extends BintasticProject>(
    */
   async function setupProject() {
     project =
-      'createProject' in mergedOptions
+      typeof mergedOptions.createProject === 'function'
         ? await mergedOptions.createProject()
         : (new BintasticProject() as TProject);
 


### PR DESCRIPTION
## Summary
- **CHK-002**: Replaces \`as Required<BintasticOptions<TProject>>\` cast with \`BintasticOptions<TProject> & { staticArgs: string[] }\`, which accurately represents what the object spread guarantees. \`createProject\` remains optional in the type.
- **CHK-003**: Rewrites \`parseArgs\` to use explicit type narrowing (\`filter((a): a is string => ...)\`) instead of \`as RunOptions\` casts, eliminating a real type mismatch that was being suppressed by unsafe assertions.

## Checklist items
Closes CHK-002 and CHK-003 from EVAL-CHECKLIST.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)