### PR TITLE
fix: dispose previous project on double setupProject call (CHK-004)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 dist/
 docs/
 node_modules
+.worktrees/

--- a/src/create-bintastic.ts
+++ b/src/create-bintastic.ts
@@ -187,6 +187,10 @@ export function createBintastic<TProject extends BintasticProject>(
    * Sets up the specified project for use within tests.
    */
   async function setupProject() {
+    if (project) {
+      project.dispose();
+    }
+
     project =
       'createProject' in mergedOptions
         ? await mergedOptions.createProject()

--- a/tests/index-test.ts
+++ b/tests/index-test.ts
@@ -200,6 +200,21 @@ describe('createBintastic', () => {
     expect(existsSync(project.baseDir)).toEqual(false);
   });
 
+  test('setupProject called twice disposes the first project directory', async () => {
+    const { setupProject, teardownProject } = createBintastic({
+      binPath: './foo',
+    });
+
+    const firstProject = await setupProject();
+    const firstBaseDir = firstProject.baseDir;
+
+    await setupProject();
+
+    expect(existsSync(firstBaseDir)).toEqual(false);
+
+    teardownProject();
+  });
+
   test('BINTASTIC_DEBUG preserves tmp dir on teardown', async () => {
     const { setupProject, teardownProject, runBin } = createBintastic({
       binPath: fileURLToPath(new URL('fixtures/fake-bin.js', import.meta.url)),


### PR DESCRIPTION
## Summary
- Adds a \`project.dispose()\` call before overwriting the closure \`project\` variable in \`setupProject()\`
- Prevents temp directory leaks when \`setupProject()\` is called more than once, or when \`setupTmpDir()\` (which lazily initializes the project) is followed by an explicit \`setupProject()\` call
- Adds a regression test verifying the first project's directory is cleaned up on the second call

## Checklist item
Closes CHK-004 from EVAL-CHECKLIST.md

🤖 Generated with [Claude Code](https://claude.com/claude-code)