### PR TITLE
feat: add fixture template helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,9 +75,13 @@ teardownProject(); // removes temp directory
 **Writing fixture files:**
 
 ```ts snippet=writing-fixtures.ts
+import { json, text } from 'bintastic';
+
 project.files = {
-  'src/index.js': 'export default 42;',
-  'package.json': JSON.stringify({ name: 'test' }),
+  'src/index.js': text`
+    export default 42;
+  `,
+  'package.json': json`{ "name": "test" }`,
 };
 await project.write();
 ```

--- a/README.md
+++ b/README.md
@@ -81,10 +81,12 @@ project.files = {
   'src/index.js': text`
     export default 42;
   `,
-  'package.json': json`{ "name": "test" }`,
+  'tsconfig.json': json`{ "compilerOptions": { "strict": true } }`,
 };
 await project.write();
 ```
+
+> **Note:** `package.json` is configured through the project constructor or `project.pkg`, not through `files`. fixturify-project serializes it from the project's package metadata, so a `json` value assigned to `files['package.json']` is ignored.
 
 **Running your CLI:**
 

--- a/snippets/writing-fixtures.ts
+++ b/snippets/writing-fixtures.ts
@@ -1,5 +1,9 @@
+import { json, text } from 'bintastic';
+
 project.files = {
-  'src/index.js': 'export default 42;',
-  'package.json': JSON.stringify({ name: 'test' }),
+  'src/index.js': text`
+    export default 42;
+  `,
+  'package.json': json`{ "name": "test" }`,
 };
 await project.write();

--- a/snippets/writing-fixtures.ts
+++ b/snippets/writing-fixtures.ts
@@ -4,6 +4,6 @@ project.files = {
   'src/index.js': text`
     export default 42;
   `,
-  'package.json': json`{ "name": "test" }`,
+  'tsconfig.json': json`{ "compilerOptions": { "strict": true } }`,
 };
 await project.write();

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,6 +4,8 @@ export {
   CreateBintasticResult,
   RunBin,
 } from './create-bintastic';
+export { json } from './json';
 export { default as BintasticProject } from './project';
+export { text } from './text';
 export type { DirJSON } from 'fixturify';
 export type { Options, Result, ResultPromise } from 'execa';

--- a/src/json.ts
+++ b/src/json.ts
@@ -1,0 +1,33 @@
+/**
+ * Serializes an interpolated template value as JSON.
+ * @param {unknown} value - The value to serialize.
+ * @returns {string} The serialized JSON value.
+ */
+function stringifyTemplateValue(value: unknown): string {
+  const stringified = JSON.stringify(value);
+
+  if (typeof stringified === 'undefined') {
+    throw new TypeError('[bintastic] json template values must be JSON-serializable');
+  }
+
+  return stringified;
+}
+
+/**
+ * Creates JSON file content from a template string.
+ * The template is parsed as JSON and returned as normalized JSON.stringify output.
+ * Interpolated values are serialized with JSON.stringify before parsing.
+ * @param {TemplateStringsArray} strings - The JSON template string segments.
+ * @param {unknown[]} values - Values to serialize into the JSON template.
+ * @returns {string} The normalized JSON file content.
+ */
+export function json(strings: TemplateStringsArray, ...values: unknown[]): string {
+  let source = strings.raw[0] ?? '';
+
+  for (const [index, value] of values.entries()) {
+    source += stringifyTemplateValue(value);
+    source += strings.raw[index + 1] ?? '';
+  }
+
+  return JSON.stringify(JSON.parse(source));
+}

--- a/src/json.ts
+++ b/src/json.ts
@@ -1,10 +1,24 @@
 /**
- * Serializes an interpolated template value as JSON.
+ * Serializes an interpolated template value as JSON, rejecting any value that
+ * cannot be faithfully represented (undefined, functions, symbols, non-finite
+ * numbers anywhere in the value, BigInts, and circular references).
  * @param {unknown} value - The value to serialize.
  * @returns {string} The serialized JSON value.
  */
 function stringifyTemplateValue(value: unknown): string {
-  const stringified = JSON.stringify(value);
+  let stringified: string | undefined;
+
+  try {
+    stringified = JSON.stringify(value, (_key, current) => {
+      if (typeof current === 'number' && !Number.isFinite(current)) {
+        throw new TypeError('[bintastic] non-finite number');
+      }
+
+      return current;
+    });
+  } catch {
+    throw new TypeError('[bintastic] json template values must be JSON-serializable');
+  }
 
   if (typeof stringified === 'undefined') {
     throw new TypeError('[bintastic] json template values must be JSON-serializable');
@@ -15,18 +29,27 @@ function stringifyTemplateValue(value: unknown): string {
 
 /**
  * Creates JSON file content from a template string.
- * The template is parsed as JSON and returned as normalized JSON.stringify output.
- * Interpolated values are serialized with JSON.stringify before parsing.
+ *
+ * The template is parsed as JSON and returned as normalized `JSON.stringify`
+ * output, so original whitespace and formatting are not preserved and comments
+ * (JSONC) are not supported. Interpolated values are serialized with
+ * `JSON.stringify` before parsing. No trailing newline is added; append one
+ * explicitly if the file requires it.
+ *
+ * Note: `package.json` is special-cased by fixturify-project and is serialized
+ * from the project's `pkg`, not from `files`, so assigning `json` content to
+ * `files['package.json']` has no effect. Configure it via the project
+ * constructor or `project.pkg` instead.
  * @param {TemplateStringsArray} strings - The JSON template string segments.
  * @param {unknown[]} values - Values to serialize into the JSON template.
  * @returns {string} The normalized JSON file content.
  */
 export function json(strings: TemplateStringsArray, ...values: unknown[]): string {
-  let source = strings.raw[0] ?? '';
+  let source = strings.raw[0];
 
   for (const [index, value] of values.entries()) {
     source += stringifyTemplateValue(value);
-    source += strings.raw[index + 1] ?? '';
+    source += strings.raw[index + 1];
   }
 
   return JSON.stringify(JSON.parse(source));

--- a/src/text.ts
+++ b/src/text.ts
@@ -1,0 +1,64 @@
+/**
+ * Gets the number of leading whitespace characters on a line.
+ * @param {string} line - The line to inspect.
+ * @returns {number} The leading whitespace length.
+ */
+function leadingWhitespaceLength(line: string): number {
+  const match = /^[\t ]*/.exec(line);
+
+  return match?.[0].length ?? 0;
+}
+
+/**
+ * Removes blank lines from the start and end of a line list.
+ * @param {string[]} lines - The lines to trim.
+ * @returns {string[]} The trimmed lines.
+ */
+function trimBlankBoundaryLines(lines: string[]): string[] {
+  let start = 0;
+  let end = lines.length;
+
+  while (start < end && lines[start].trim() === '') {
+    start++;
+  }
+
+  while (end > start && lines[end - 1].trim() === '') {
+    end--;
+  }
+
+  return lines.slice(start, end);
+}
+
+/**
+ * Removes common indentation from text.
+ * @param {string} source - The text to dedent.
+ * @returns {string} The dedented text.
+ */
+function dedent(source: string): string {
+  const lines = trimBlankBoundaryLines(source.replaceAll('\r\n', '\n').split('\n'));
+  const contentLines = lines.filter((line) => line.trim() !== '');
+  const minimumIndent =
+    contentLines.length === 0
+      ? 0
+      : Math.min(...contentLines.map((line) => leadingWhitespaceLength(line)));
+
+  return lines.map((line) => line.slice(minimumIndent)).join('\n');
+}
+
+/**
+ * Creates text file content from a template string.
+ * The template has leading and trailing blank lines removed, then common indentation is stripped.
+ * @param {TemplateStringsArray} strings - The text template string segments.
+ * @param {unknown[]} values - Values to interpolate into the text template.
+ * @returns {string} The normalized text file content.
+ */
+export function text(strings: TemplateStringsArray, ...values: unknown[]): string {
+  let source = strings[0] ?? '';
+
+  for (const [index, value] of values.entries()) {
+    source += String(value);
+    source += strings[index + 1] ?? '';
+  }
+
+  return dedent(source);
+}

--- a/src/text.ts
+++ b/src/text.ts
@@ -1,12 +1,33 @@
 /**
- * Gets the number of leading whitespace characters on a line.
+ * Gets the leading whitespace (spaces and tabs) of a line.
  * @param {string} line - The line to inspect.
- * @returns {number} The leading whitespace length.
+ * @returns {string} The leading whitespace.
  */
-function leadingWhitespaceLength(line: string): number {
-  const match = /^[\t ]*/.exec(line);
+function leadingWhitespace(line: string): string {
+  let length = 0;
 
-  return match?.[0].length ?? 0;
+  while (length < line.length && (line[length] === ' ' || line[length] === '\t')) {
+    length++;
+  }
+
+  return line.slice(0, length);
+}
+
+/**
+ * Gets the longest common prefix shared by two strings.
+ * @param {string} a - The first string.
+ * @param {string} b - The second string.
+ * @returns {string} The shared prefix.
+ */
+function sharedPrefix(a: string, b: string): string {
+  let length = 0;
+  const max = Math.min(a.length, b.length);
+
+  while (length < max && a[length] === b[length]) {
+    length++;
+  }
+
+  return a.slice(0, length);
 }
 
 /**
@@ -30,35 +51,107 @@ function trimBlankBoundaryLines(lines: string[]): string[] {
 }
 
 /**
- * Removes common indentation from text.
- * @param {string} source - The text to dedent.
- * @returns {string} The dedented text.
+ * Normalizes line endings to "\n", converting both "\r\n" pairs and lone "\r".
+ * @param {string} segment - The segment to normalize.
+ * @returns {string} The normalized segment.
  */
-function dedent(source: string): string {
-  const lines = trimBlankBoundaryLines(source.replaceAll('\r\n', '\n').split('\n'));
-  const contentLines = lines.filter((line) => line.trim() !== '');
-  const minimumIndent =
-    contentLines.length === 0
-      ? 0
-      : Math.min(...contentLines.map((line) => leadingWhitespaceLength(line)));
+function normalizeNewlines(segment: string): string {
+  return segment.replaceAll('\r\n', '\n').replaceAll('\r', '\n');
+}
 
-  return lines.map((line) => line.slice(minimumIndent)).join('\n');
+/**
+ * Determines whether a line begins a physical line of the template literal.
+ * The first line of the template owns its indentation, as does every line that
+ * follows a newline within a segment. Lines that merely continue after an
+ * interpolated value do not, so their content is emitted unchanged.
+ * @param {number} segmentIndex - The index of the segment the line is in.
+ * @param {number} lineIndex - The index of the line within the segment.
+ * @returns {boolean} Whether the line owns its indentation.
+ */
+function startsTemplateLine(segmentIndex: number, lineIndex: number): boolean {
+  return segmentIndex === 0 || lineIndex > 0;
+}
+
+/**
+ * Removes the common indentation from a template line, normalizing
+ * whitespace-only lines to empty so they render as truly blank lines.
+ * @param {string} line - The template line to strip.
+ * @param {string} indent - The common indentation prefix to remove.
+ * @returns {string} The stripped line.
+ */
+function stripTemplateIndent(line: string, indent: string): string {
+  if (line.trim() === '') {
+    return '';
+  }
+
+  return line.slice(sharedPrefix(line, indent).length);
+}
+
+/**
+ * Computes the indentation common to the template's physical lines, ignoring
+ * blank lines, lines flush to the margin, and any content contributed by
+ * interpolated values.
+ * @param {string[]} segments - The normalized template segments.
+ * @returns {string} The common leading-whitespace prefix.
+ */
+function commonTemplateIndent(segments: string[]): string {
+  let common: string | undefined;
+
+  for (const [segmentIndex, segment] of segments.entries()) {
+    for (const [lineIndex, line] of segment.split('\n').entries()) {
+      if (!startsTemplateLine(segmentIndex, lineIndex) || line.trim() === '') {
+        continue;
+      }
+
+      const indent = leadingWhitespace(line);
+
+      // A line flush to the margin doesn't constrain the common indentation;
+      // counting its empty indent would otherwise disable dedenting for the
+      // entire block (e.g. content written on the opening backtick line).
+      if (indent === '') {
+        continue;
+      }
+
+      common = common === undefined ? indent : sharedPrefix(common, indent);
+    }
+  }
+
+  return common ?? '';
 }
 
 /**
  * Creates text file content from a template string.
- * The template has leading and trailing blank lines removed, then common indentation is stripped.
+ *
+ * Leading and trailing blank lines are removed and the indentation common to
+ * the template literal is stripped. The indentation is computed only from the
+ * template text, so interpolated values are inserted verbatim: a multi-line
+ * value neither changes the detected indent nor gets re-indented. No trailing
+ * newline is added; append one explicitly if the file requires it.
  * @param {TemplateStringsArray} strings - The text template string segments.
  * @param {unknown[]} values - Values to interpolate into the text template.
  * @returns {string} The normalized text file content.
  */
 export function text(strings: TemplateStringsArray, ...values: unknown[]): string {
-  let source = strings[0] ?? '';
+  const segments = strings.map((segment) => normalizeNewlines(segment));
+  const indent = commonTemplateIndent(segments);
 
-  for (const [index, value] of values.entries()) {
-    source += String(value);
-    source += strings[index + 1] ?? '';
+  let result = '';
+
+  for (const [segmentIndex, segment] of segments.entries()) {
+    if (segmentIndex > 0) {
+      result += String(values[segmentIndex - 1]);
+    }
+
+    for (const [lineIndex, line] of segment.split('\n').entries()) {
+      if (lineIndex > 0) {
+        result += '\n';
+      }
+
+      result += startsTemplateLine(segmentIndex, lineIndex)
+        ? stripTemplateIndent(line, indent)
+        : line;
+    }
   }
 
-  return dedent(source);
+  return trimBlankBoundaryLines(result.split('\n')).join('\n');
 }

--- a/tests/index-test.ts
+++ b/tests/index-test.ts
@@ -293,6 +293,27 @@ describe('json', () => {
       '[bintastic] json template values must be JSON-serializable'
     );
   });
+
+  test('throws when an interpolated number is not finite', () => {
+    expect(() => json`{ "value": ${Number.NaN} }`).toThrow(
+      '[bintastic] json template values must be JSON-serializable'
+    );
+    expect(() => json`{ "value": ${Infinity} }`).toThrow(
+      '[bintastic] json template values must be JSON-serializable'
+    );
+  });
+
+  test('throws when a non-finite number is nested inside an interpolated value', () => {
+    expect(() => json`{ "value": ${{ count: Number.NaN }} }`).toThrow(
+      '[bintastic] json template values must be JSON-serializable'
+    );
+  });
+
+  test('throws a branded error when an interpolated value is a BigInt', () => {
+    expect(() => json`{ "value": ${10n} }`).toThrow(
+      '[bintastic] json template values must be JSON-serializable'
+    );
+  });
 });
 
 describe('text', () => {
@@ -318,5 +339,48 @@ describe('text', () => {
     expect(text`
       export const name = '${name}';
     `).toEqual("export const name = 'fixture';");
+  });
+
+  test('dedents the template without re-indenting multi-line interpolated values', () => {
+    const value = 'first\nsecond';
+
+    expect(text`
+      const x = "${value}";
+      const y = 1;
+    `).toEqual('const x = "first\nsecond";\nconst y = 1;');
+  });
+
+  test('normalizes carriage returns in the template', () => {
+    const template = ['\n  a\r\n  b\r  c\n'] as unknown as TemplateStringsArray;
+
+    expect(text(template)).toEqual('a\nb\nc');
+  });
+
+  test('leaves content untouched when indentation mixes tabs and spaces', () => {
+    const template = ['\n\tconst a = 1;\n  const b = 2;\n'] as unknown as TemplateStringsArray;
+
+    expect(text(template)).toEqual('\tconst a = 1;\n  const b = 2;');
+  });
+
+  test('dedents the remaining lines when content starts on the opening line', () => {
+    expect(text`first
+      second
+      third`).toEqual('first\nsecond\nthird');
+  });
+
+  test('ignores flush lines when computing common indentation', () => {
+    const template = ['\n  a\nb\n  c\n'] as unknown as TemplateStringsArray;
+
+    expect(text(template)).toEqual('a\nb\nc');
+  });
+
+  test('normalizes whitespace-only lines to empty', () => {
+    const template = ['\n    a\n        \n    b\n'] as unknown as TemplateStringsArray;
+
+    expect(text(template)).toEqual('a\n\nb');
+  });
+
+  test('coerces interpolated values the same way a native template literal does', () => {
+    expect(text`count=${42}`).toEqual('count=42');
   });
 });

--- a/tests/index-test.ts
+++ b/tests/index-test.ts
@@ -1,7 +1,7 @@
 import { statSync, existsSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
 import { describe, test, expect } from 'vitest';
-import { createBintastic, BintasticProject } from '../src';
+import { createBintastic, BintasticProject, json, text } from '../src';
 
 class FakeProject extends BintasticProject {}
 
@@ -270,5 +270,53 @@ describe('createBintastic', () => {
     }
 
     expect(existsSync(project.baseDir)).toEqual(false);
+  });
+});
+
+describe('json', () => {
+  test('stringifies JSON template content', () => {
+    expect(json`{ "foo": "bar" }`).toEqual('{"foo":"bar"}');
+  });
+
+  test('serializes interpolated values as JSON', () => {
+    expect(
+      json`{ "name": ${'test'}, "nested": ${{ enabled: true }}, "items": ${['a', 'b']} }`
+    ).toEqual('{"name":"test","nested":{"enabled":true},"items":["a","b"]}');
+  });
+
+  test('throws when template content is not valid JSON', () => {
+    expect(() => json`{ foo: "bar" }`).toThrow(SyntaxError);
+  });
+
+  test('throws when an interpolated value is not JSON-serializable', () => {
+    expect(() => json`{ "value": ${undefined} }`).toThrow(
+      '[bintastic] json template values must be JSON-serializable'
+    );
+  });
+});
+
+describe('text', () => {
+  test('dedents text template content', () => {
+    expect(text`
+      export function main() {
+        console.log('hello');
+      }
+    `).toEqual("export function main() {\n  console.log('hello');\n}");
+  });
+
+  test('preserves intentional blank lines inside content', () => {
+    expect(text`
+      # Title
+
+      Body text.
+    `).toEqual('# Title\n\nBody text.');
+  });
+
+  test('serializes interpolated values as text', () => {
+    const name = 'fixture';
+
+    expect(text`
+      export const name = '${name}';
+    `).toEqual("export const name = 'fixture';");
   });
 });


### PR DESCRIPTION
## Summary
- add `json` tagged template helper for JSON fixture content
- add `text` tagged template helper for dedented multiline fixture content
- document both helpers in the fixture-writing snippet

## Validation
- npm test
- npm run build