### PR TITLE
fix(deps): override tmp to ^0.2.7 to patch path traversal advisory

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8061,18 +8061,6 @@
         "node": ">= 14.*"
       }
     },
-    "node_modules/fixturify-project/node_modules/tmp": {
-      "version": "0.0.33",
-      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
-      "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
-      "license": "MIT",
-      "dependencies": {
-        "os-tmpdir": "~1.0.2"
-      },
-      "engines": {
-        "node": ">=0.6.0"
-      }
-    },
     "node_modules/fixturify-project/node_modules/type-fest": {
       "version": "4.41.0",
       "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-4.41.0.tgz",
@@ -11153,15 +11141,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/os-tmpdir": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/os-tmpdir/-/os-tmpdir-1.0.2.tgz",
-      "integrity": "sha512-D2FR03Vir7FIu45XBY20mTb+/ZSWB00sjU9jdQXt83gDrI4Ztz5Fs7/yy74g2N5SVQY4xY1qDr4rNddwYRVX0g==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/p-defer": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/p-defer/-/p-defer-1.0.0.tgz",
@@ -13024,10 +13003,9 @@
       }
     },
     "node_modules/tmp": {
-      "version": "0.2.5",
-      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.5.tgz",
-      "integrity": "sha512-voyz6MApa1rQGUxT3E+BK7/ROe8itEx7vD8/HEvt4xwXucvQ5G5oeEiHkmHZJuBO21RpOf+YYm9MOivj709jow==",
-      "dev": true,
+      "version": "0.2.7",
+      "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.7.tgz",
+      "integrity": "sha512-e0votIpp4Uo2AJYSzVHV6xCcawuiez3DzqDAbrTc3YxBkplN6e+dM13ZeIcZnDg/QpSuU2zfZ3rzwY8ukEnaXw==",
       "license": "MIT",
       "engines": {
         "node": ">=14.14"

--- a/package.json
+++ b/package.json
@@ -100,5 +100,8 @@
       "release": true,
       "tokenRef": "GITHUB_AUTH"
     }
+  },
+  "overrides": {
+    "tmp": "^0.2.7"
   }
 }


### PR DESCRIPTION
## Summary

`fixturify-project` (a runtime dependency) pins `tmp@^0.0.33`, which is vulnerable to path traversal via unsanitized prefix/postfix (GHSA-ph9p-34f9-6g65). `fixturify-project@7.1.3` is the latest release and still pins the vulnerable range, so there is no forward fix available.

This PR adds an npm `overrides` entry forcing `tmp` to `^0.2.7`:

- Clears the **only** vulnerability in the runtime dependency path (the one consumers of bintastic actually install).
- Also resolves the second, dev-scope copy of `tmp` pulled in transitively via `lerna-changelog`.

The remaining `npm audit` findings are all in dev-only release tooling (`release-it` -> `undici`, and the unmaintained `lerna-changelog` -> `tar`/`@tootallnate/once` chain) and are never installed by consumers.

## Compatibility

`fixturify-project` only calls `tmp.setGracefulCleanup()` and `tmp.dirSync({ unsafeCleanup: true })`, both stable across the 0.0.33 -> 0.2.7 jump.

## Testing

- `npm run test:vitest` — all 32 tests pass against the patched `tmp`.
- `npm ls tmp` confirms both instances now resolve to `0.2.7`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)