### PR TITLE
feat: resolve binPath relative to importMeta.url

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,6 +10,7 @@ This file provides guidance to Claude Code (claude.ai/code) when working with co
 - Modify version numbers in package.json for release purposes
 - Amend or modify release commits
 - Create release tags
+- Hand-edit `CHANGELOG.md` — it is generated entirely by release-it (lerna-changelog) from merged PR titles. Never add headings, sections, or entries to it, not even an "Unreleased" section.
 
 The maintainer handles all releases manually.
 

--- a/README.md
+++ b/README.md
@@ -22,7 +22,8 @@ import { createBintastic } from 'bintastic';
 
 describe('my-cli', () => {
   const { setupProject, teardownProject, runBin } = createBintastic({
-    binPath: './bin/my-cli.js',
+    importMeta: import.meta,
+    binPath: './bin/my-cli.js', // resolved relative to this test module
   });
 
   let project;
@@ -59,8 +60,24 @@ npm add bintastic --save-dev
 
 ```ts snippet=create-bintastic.ts
 const { setupProject, teardownProject, runBin } = createBintastic({
-  binPath: './bin/my-cli.js',
+  importMeta: import.meta,
+  binPath: './bin/my-cli.js', // resolved relative to this module
   staticArgs: ['--verbose'], // args passed to every invocation
+});
+```
+
+**Resolving `binPath`:**
+
+Pass `importMeta: import.meta` and a `binPath` relative to the importing module—bintastic resolves it with `fileURLToPath(new URL(binPath, importMeta.url))`. This is the recommended form. If `binPath` is a function, its returned path is resolved the same way.
+
+Without `importMeta`, `binPath` must be an absolute path that you pre-resolve yourself:
+
+```ts snippet=legacy-bin-path.ts
+import { fileURLToPath } from 'node:url';
+
+// Without `importMeta`, `binPath` must be an absolute path. Pre-resolve it yourself:
+const { setupProject, teardownProject, runBin } = createBintastic({
+  binPath: fileURLToPath(new URL('./bin/my-cli.js', import.meta.url)),
 });
 ```
 

--- a/snippets/basic-example.ts
+++ b/snippets/basic-example.ts
@@ -2,7 +2,8 @@ import { createBintastic } from 'bintastic';
 
 describe('my-cli', () => {
   const { setupProject, teardownProject, runBin } = createBintastic({
-    binPath: './bin/my-cli.js',
+    importMeta: import.meta,
+    binPath: './bin/my-cli.js', // resolved relative to this test module
   });
 
   let project;

--- a/snippets/create-bintastic.ts
+++ b/snippets/create-bintastic.ts
@@ -1,4 +1,5 @@
 const { setupProject, teardownProject, runBin } = createBintastic({
-  binPath: './bin/my-cli.js',
+  importMeta: import.meta,
+  binPath: './bin/my-cli.js', // resolved relative to this module
   staticArgs: ['--verbose'], // args passed to every invocation
 });

--- a/snippets/legacy-bin-path.ts
+++ b/snippets/legacy-bin-path.ts
@@ -1,0 +1,6 @@
+import { fileURLToPath } from 'node:url';
+
+// Without `importMeta`, `binPath` must be an absolute path. Pre-resolve it yourself:
+const { setupProject, teardownProject, runBin } = createBintastic({
+  binPath: fileURLToPath(new URL('./bin/my-cli.js', import.meta.url)),
+});

--- a/src/create-bintastic.ts
+++ b/src/create-bintastic.ts
@@ -1,11 +1,21 @@
+import { fileURLToPath } from 'node:url';
 import { execaNode, type Options, type ResultPromise } from 'execa';
 import BintasticProject from './project';
+
 /**
- * Options for configuring bintastic.
+ * Options shared by every way of configuring bintastic.
  */
-export interface BintasticOptions<TProject> {
+interface BintasticOptionsBase<TProject> {
   /**
-   * The absolute path to the bin to invoke
+   * The path to the bin to invoke.
+   *
+   * When {@link ImportMetaBintasticOptions.importMeta | importMeta} is provided, this is treated as
+   * a path relative to the importing module and resolved via
+   * `fileURLToPath(new URL(binPath, importMeta.url))`. Otherwise it must be an
+   * absolute path (typically pre-resolved by the caller).
+   *
+   * May also be a function that receives the project and returns the path. The
+   * returned value is resolved using the same rule.
    */
   binPath: string | ((project: TProject) => string);
   /**
@@ -17,6 +27,37 @@ export interface BintasticOptions<TProject> {
    */
   createProject?: () => Promise<TProject>;
 }
+
+/**
+ * Options where `binPath` is an already-resolved absolute path.
+ */
+export interface ResolvedBintasticOptions<TProject> extends BintasticOptionsBase<TProject> {
+  /**
+   * Must be absent. Provide {@link ImportMetaBintasticOptions} to resolve a relative `binPath`.
+   */
+  importMeta?: undefined;
+}
+
+/**
+ * Options where `binPath` is relative to the importing module, resolved against `importMeta.url`.
+ */
+export interface ImportMetaBintasticOptions<TProject> extends BintasticOptionsBase<TProject> {
+  /**
+   * The `import.meta` of the module configuring bintastic. Used to resolve a
+   * relative `binPath` to an absolute path.
+   */
+  importMeta: ImportMeta;
+}
+
+/**
+ * Options for configuring bintastic.
+ *
+ * Either provide an absolute `binPath` ({@link ResolvedBintasticOptions}) or pass
+ * `importMeta` alongside a relative `binPath` ({@link ImportMetaBintasticOptions}).
+ */
+export type BintasticOptions<TProject> =
+  | ResolvedBintasticOptions<TProject>
+  | ImportMetaBintasticOptions<TProject>;
 
 interface RunOptions {
   /**
@@ -131,6 +172,23 @@ export function createBintastic<TProject extends BintasticProject>(
   } as BintasticOptions<TProject> & { staticArgs: string[] };
 
   /**
+   * Resolves the configured binPath to an absolute path. Calls binPath when it is
+   * a function, then resolves the result relative to importMeta.url when provided.
+   * @param {TProject} forProject - The active project, passed to a binPath function.
+   * @returns {string} The absolute path to the bin script.
+   */
+  function resolveBinPath(forProject: TProject): string {
+    const rawBinPath =
+      typeof mergedOptions.binPath === 'function'
+        ? mergedOptions.binPath(forProject)
+        : mergedOptions.binPath;
+
+    return mergedOptions.importMeta
+      ? fileURLToPath(new URL(rawBinPath, mergedOptions.importMeta.url))
+      : rawBinPath;
+  }
+
+  /**
    * Shared execution body for runBin and runBinDebug. Parses debug env, sets inspector
    * flags, and updates _preserveFixtures so teardownProject sees debug state correctly.
    * @param {RunOptions} parsedArgs - Already-parsed arguments and execa options.
@@ -169,11 +227,7 @@ export function createBintastic<TProject extends BintasticProject>(
   function runBin(...args: RunBinArgs): ResultPromise {
     if (!project) throw new Error('[bintastic] setupProject() must be called before runBin()');
     const parsedArgs = parseArgs(args);
-    const binPath =
-      typeof mergedOptions.binPath === 'function'
-        ? mergedOptions.binPath(project)
-        : mergedOptions.binPath;
-    return _runBinInternal(parsedArgs, binPath);
+    return _runBinInternal(parsedArgs, resolveBinPath(project));
   }
 
   /**
@@ -191,11 +245,7 @@ export function createBintastic<TProject extends BintasticProject>(
         BINTASTIC_DEBUG: debugEnv,
       },
     };
-    const binPath =
-      typeof mergedOptions.binPath === 'function'
-        ? mergedOptions.binPath(project)
-        : mergedOptions.binPath;
-    return _runBinInternal(parsedArgs, binPath);
+    return _runBinInternal(parsedArgs, resolveBinPath(project));
   }
 
   /**

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,8 @@
 export {
   createBintastic,
   BintasticOptions,
+  ResolvedBintasticOptions,
+  ImportMetaBintasticOptions,
   CreateBintasticResult,
   RunBin,
 } from './create-bintastic';

--- a/tests/index-test.ts
+++ b/tests/index-test.ts
@@ -62,9 +62,10 @@ describe('createBintastic', () => {
     expect(existsSync(project.baseDir)).toEqual(false);
   });
 
-  test('runBin can run the configured bin script', async () => {
+  test('runBin resolves a relative binPath against importMeta.url', async () => {
     const { setupProject, teardownProject, runBin } = createBintastic({
-      binPath: fileURLToPath(new URL('fixtures/fake-bin.js', import.meta.url)),
+      importMeta: import.meta,
+      binPath: 'fixtures/fake-bin.js',
     });
 
     const project = await setupProject();
@@ -78,12 +79,29 @@ describe('createBintastic', () => {
     expect(existsSync(project.baseDir)).toEqual(false);
   });
 
-  test('runBin can run the configured bin script dynamically', async () => {
+  test('runBin resolves a function binPath against importMeta.url', async () => {
     const { setupProject, teardownProject, runBin } = createBintastic({
+      importMeta: import.meta,
       binPath: (p) => {
         expect(p).toEqual(project);
-        return fileURLToPath(new URL('fixtures/fake-bin.js', import.meta.url));
+        return 'fixtures/fake-bin.js';
       },
+    });
+
+    const project = await setupProject();
+
+    const result = await runBin();
+
+    expect(result.stdout).toMatchInlineSnapshot('"I am a bin who takes args []"');
+
+    teardownProject();
+
+    expect(existsSync(project.baseDir)).toEqual(false);
+  });
+
+  test('runBin accepts a pre-resolved absolute binPath (legacy)', async () => {
+    const { setupProject, teardownProject, runBin } = createBintastic({
+      binPath: fileURLToPath(new URL('fixtures/fake-bin.js', import.meta.url)),
     });
 
     const project = await setupProject();
@@ -99,7 +117,8 @@ describe('createBintastic', () => {
 
   test('runBin can run the configured bin script with static arguments', async () => {
     const { setupProject, teardownProject, runBin } = createBintastic({
-      binPath: fileURLToPath(new URL('fixtures/fake-bin.js', import.meta.url)),
+      importMeta: import.meta,
+      binPath: 'fixtures/fake-bin.js',
       staticArgs: ['--static', 'true'],
     });
 
@@ -118,7 +137,8 @@ describe('createBintastic', () => {
 
   test('runBin can run the configured bin script with arguments', async () => {
     const { setupProject, teardownProject, runBin } = createBintastic({
-      binPath: fileURLToPath(new URL('fixtures/fake-bin.js', import.meta.url)),
+      importMeta: import.meta,
+      binPath: 'fixtures/fake-bin.js',
     });
 
     const project = await setupProject();
@@ -136,7 +156,8 @@ describe('createBintastic', () => {
 
   test('runBin can run the configured bin script with arguments and execa options', async () => {
     const { setupProject, teardownProject, runBin } = createBintastic({
-      binPath: fileURLToPath(new URL('fixtures/fake-bin-with-env.js', import.meta.url)),
+      importMeta: import.meta,
+      binPath: 'fixtures/fake-bin-with-env.js',
     });
 
     const project = await setupProject();


### PR DESCRIPTION
## Summary

`createBintastic` now accepts `importMeta: import.meta` alongside a relative `binPath`, resolving it with `fileURLToPath(new URL(binPath, importMeta.url))` (meow-style). This removes the boilerplate of pre-resolving paths at every call site.

- A `binPath` function's return value is resolved the same way.
- Passing an absolute `binPath` without `importMeta` is unchanged (backward compatible).
- `BintasticOptions` is now a discriminated union over `importMeta`: `ResolvedBintasticOptions` (absolute path) or `ImportMetaBintasticOptions` (relative path + `importMeta`), so the two forms can't be mixed ambiguously.

## Test plan

- New tests cover relative-string, relative-function, and pre-resolved-absolute (legacy) resolution; README/snippets updated with the new form as primary.
- `npm test` green: ESLint, Prettier, docs:check, 33/33 vitest tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)